### PR TITLE
add whitelist/blacklist for all styling

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,4 +1,5 @@
 let SKIP_FORCE_THEMING_KEY = "skipForceThemingList";
+let SKIP_THEMING_KEY = "skipThemingList";
 let logging = true; // Enable logging for debugging
 
 // Create a cache for pre-processed CSS to speed up repeated visits
@@ -231,8 +232,16 @@ async function applyCSSToTab(tab) {
     const globalSettings = settings.transparentZenSettings || {};
     console.log("DEBUG: Global settings:", JSON.stringify(globalSettings));
 
-    if (globalSettings.enableStyling === false) {
-      console.log("DEBUG: Styling is globally disabled, exiting early");
+    const skipStyleListData = await browser.storage.local.get(
+      SKIP_THEMING_KEY
+    );
+    const skipStyleList = skipStyleListData[SKIP_THEMING_KEY] || [];
+    const styleMode = globalSettings.whitelistStyleMode ?? true;
+
+    if (globalSettings.enableStyling === false || 
+      !styleMode && skipStyleList.includes(hostname) ||
+      styleMode && !skipStyleList.includes(hostname)) {
+      console.log("DEBUG: Styling is disabled, exiting early");
       return;
     }
 

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -26,12 +26,28 @@
     </header>
 
     <main class="app-content">
-      <div class="toggle-container features-container">
+      <div class="features-container">
+      <div class="toggle-container">
         <label class="toggle-switch">
           <input type="checkbox" id="enable-styling">
           <span class="slider round"></span>
         </label>
         <span class="toggle-label">Enable Styling</span>
+      </div>
+        <div class="toggle-container">
+          <label class="toggle-switch">
+            <input type="checkbox" id="whitelist-style-mode">
+            <span class="slider round"></span>
+          </label>
+          <span id="whitelist-style-mode-label" class="toggle-label">Blacklist Mode</span>
+        </div>
+        <div class="toggle-container">
+          <label class="toggle-switch">
+            <input type="checkbox" id="skip-theming">
+            <span class="slider round"></span>
+          </label>
+          <span id="site-style-toggle-label" class="toggle-label">Skip Styling for this Site</span>
+        </div>
       </div>
 
       <!-- Current Site Features Section -->


### PR DESCRIPTION
added a slider similar to force styling blacklist, with very similar functionality, but for non-forced styles.

implementation is similar to how the blacklist for force styling works, but now exits earlier where the global enable styling would've exited.

made this for fun, and because i prefer the styling on certain websites more than others.

![image](https://github.com/user-attachments/assets/4a706510-4be7-486c-82c7-1f9999f25db8)
