### PR TITLE
Load the plugin also in `iframe`s

### DIFF
--- a/background.js
+++ b/background.js
@@ -307,7 +307,7 @@ browser.runtime.onMessage.addListener(async (message, sender) => {
           .sendMessage(sender.tab.id, {
             action: "applyStyles",
             css: css,
-          })
+          }, { frameId: sender.frameId })
           .catch((err) => {
             if (logging) console.log("Failed to send immediate CSS:", err);
           });

--- a/manifest.json
+++ b/manifest.json
@@ -40,5 +40,12 @@
     "data-viewer/data-viewer.css",
     "styling/*",
     "shared/*"
+  ],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content-script.js"],
+      "all_frames": true
+    }
   ]
 }


### PR DESCRIPTION
This fixes the issue where you couldn't style `iframe` elements (e.g. [my-internet#842](https://github.com/sameerasw/my-internet/issues/842)). The extension now also gets attached to websites in `iframe` elements.