### PR TITLE
Add editable feature toggles to advanced settings page

### DIFF
--- a/data-viewer/data-viewer.css
+++ b/data-viewer/data-viewer.css
@@ -280,10 +280,33 @@ body {
   font-family: "Font Awesome 5 Free";
   font-weight: 900;
   transition: transform 0.3s ease;
+  position: absolute;
+  right: 16px;
 }
 
 .css-block-header.active::after {
   transform: rotate(180deg);
+}
+
+/* Style for the toggle switch in feature headers */
+.css-block-header .toggle-switch {
+  margin-right: 30px; /* Make room for the chevron */
+}
+
+.css-block-header .toggle-switch input[type="checkbox"] {
+  margin: 0;
+}
+
+.css-block-header .toggle-switch .slider {
+  width: 40px;
+  height: 20px;
+}
+
+.css-block-header .toggle-switch .slider::before {
+  width: 16px;
+  height: 16px;
+  left: 2px;
+  bottom: 2px;
 }
 
 .feature-name {


### PR DESCRIPTION
## Problem

Users could view website features and their enabled/disabled status in the advanced settings page, but couldn't edit them directly. This felt unnatural since they could see the status but had to go back to the popup on that specific site to make changes.

Previously, the advanced settings page showed features like this:
- ✅ **transparency** - Enabled  
- ❌ **hover-effects** - Disabled
- ✅ **remove-footer** - Enabled

## Solution

Added interactive toggle switches to each feature in the advanced settings page, allowing users to enable/disable features directly from the advanced settings without having to navigate back to the popup.

## Changes Made

### `data-viewer/data-viewer.js`
- **Replaced read-only status badges with interactive toggle switches**: Changed from displaying "Enabled/Disabled" text to actual toggle switches
- **Added event delegation**: Implemented event listener on the container to handle all toggle changes efficiently
- **Implemented `saveFeatureToggle()` function**: Uses the same storage mechanism as the popup (`transparentZenSettings.{domain}`) to ensure consistency
- **Updated click handlers**: Prevented toggle interaction from expanding/collapsing the CSS content sections

### `data-viewer/data-viewer.css`
- **Added styling for toggle switches**: Positioned toggle switches properly within feature headers
- **Repositioned chevron icon**: Moved the expand/collapse chevron to accommodate the toggle switches
- **Ensured proper spacing**: Maintained clean layout with adequate spacing between elements

## Testing

Created a comprehensive test to verify:
- ✅ Toggles show current feature status (enabled/disabled) correctly
- ✅ Clicking toggles properly changes feature state
- ✅ Changes are saved to browser storage using the same mechanism as the popup
- ✅ Toggle interaction doesn't interfere with expand/collapse functionality
- ✅ CSS content sections can still be expanded/collapsed independently


The new interface now shows toggle switches instead of read-only status text:

