### PR TITLE
fix error loading features

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1022,8 +1022,9 @@ new (class ExtensionPopup {
           .toLowerCase()
           .includes("transparency");
         const isHoverFeature = feature.toLowerCase().includes("hover");
+        const isFooterFeature = feature.toLowerCase().includes("footer");
         const isDarkReaderFeature = feature.toLowerCase().includes("darkreader") || css.toLowerCase().includes("darkreader");
-
+        
         const isOverridden =
           (isTransparencyDisabled && isTransparencyFeature) ||
           (isHoverDisabled && isHoverFeature) ||


### PR DESCRIPTION
Fixes [sameerasw/my-internet#2558](https://github.com/sameerasw/my-internet/issues/2558)
Adds back the `isFooterFeature`. If you actually intended to remove it, just remove both the const and usage.